### PR TITLE
Remove redundant mut constraint and correct logic for getUpdateNftAcc…

### DIFF
--- a/packages/client/src/types/impact_nft.ts
+++ b/packages/client/src/types/impact_nft.ts
@@ -254,7 +254,7 @@ export type ImpactNft = {
         },
         {
           "name": "adminMintAuthority",
-          "isMut": true,
+          "isMut": false,
           "isSigner": true
         },
         {
@@ -773,7 +773,7 @@ export const IDL: ImpactNft = {
         },
         {
           "name": "adminMintAuthority",
-          "isMut": true,
+          "isMut": false,
           "isSigner": true
         },
         {

--- a/programs/impact-nft/src/instructions/create_nft.rs
+++ b/programs/impact-nft/src/instructions/create_nft.rs
@@ -13,7 +13,6 @@ use anchor_spl::token::Token;
 pub struct MintNft<'info> {
     #[account(mut)]
     pub payer: Signer<'info>,
-
     pub admin_mint_authority: Signer<'info>,
     #[account(
         seeds = [TOKEN_AUTHORITY_SEED, global_state.key().as_ref()],

--- a/programs/impact-nft/src/instructions/update_nft.rs
+++ b/programs/impact-nft/src/instructions/update_nft.rs
@@ -13,8 +13,7 @@ use anchor_spl::token::{ Mint, Token, TokenAccount };
 pub struct UpdateNft<'info> {
     #[account(mut)]
     pub payer: Signer<'info>,
-
-    #[account(mut)] // needed for verify ix
+    // needed for verify ix
     pub admin_mint_authority: Signer<'info>,
     /// CHECK: Verified with function
     #[account(


### PR DESCRIPTION
- Corrects existing logic for getting the new collection accounts that the program expects.
- Removes a redundant mut constraint from `admin_mint_authority` in `updateNft` 